### PR TITLE
Fixing the "flipped" status of a record, Removed "excensus" branch notice

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -15,11 +15,6 @@ versus cardinal numbers, and more.
 Geocoder::US 2.0 is shipped with a free US ZIP code data set, compiled from
 public domain sources.
 
-== "excensus" Branch
-
-The "excensus" branch is the actively modified branch of Excensus LLC, maintained
-by Dan "Ducky" Little (GitHub: theduckylittle, dan.little-at-excensus-dot-com).
-
 == Synopsis
 
   >> require 'geocoder/us'

--- a/lib/geocoder/us/database.rb
+++ b/lib/geocoder/us/database.rb
@@ -267,12 +267,12 @@ module Geocoder::US
               FROM range WHERE tlid IN (#{in_list})
               GROUP BY tlid, side;"
       execute(sql, *edge_ids).map {|r|
-        if r[:flipped] == "0"
-          r[:flipped] = false
-          r[:fromhn], r[:tohn] = r[:from0], r[:to0]
-        else
+	if r[:flipped].to_i == 1
           r[:flipped] = true
           r[:fromhn], r[:tohn] = r[:from1], r[:to1]
+        else
+          r[:flipped] = false
+          r[:fromhn], r[:tohn] = r[:from0], r[:to0]
         end
         [:from0, :to0, :from1, :to1].each {|k| r.delete k}
         r


### PR DESCRIPTION
Hi Folks,

I found a bug while doing some large geocoding projects regarding the "flipped" status.  On some edges this caused a geocode to be placed a far-cry from where it should have been.

The bug is how the gem was handling the return of the "flipped" value from SQLite.  Since SQLite is typeless it was returning the string but not evaluating correctly in ruby.  I forced a ruby type-cast to integer using "to_i" and then looked for the value to be 1 to be truly flipped.

The other change is removing the notice about the Excensus branch.  I'm trying to keep things a bit cleaner and culled the branch.  That makes the notice in the README pretty irrelevant.
